### PR TITLE
Fix backup of secret.code

### DIFF
--- a/run-tests.sh
+++ b/run-tests.sh
@@ -29,10 +29,9 @@ function __run_test_against_task(){
     # 
     ASSERTIONS_HOME="$(realpath "${TEST_HOME}/../../assertions")"
 
-    # TODO Not sure if this is necessary or not...
     # SWAP the secret.code if there's one already (manual test)
     if [ -e ${TASK_HOME}/secret.code ]; then
-        ( >&2 echo mv -v ${TASK_HOME}/secret.code ${TASK_HOME}/secret.code.orig)
+        ( >&2 mv -v ${TASK_HOME}/secret.code ${TASK_HOME}/secret.code.orig )
     fi
 
     # Ensures that the secret.code defined inside the test is where it is supposed to be
@@ -72,7 +71,7 @@ function __run_test_against_task(){
     # Restore the files that were there before execution
     # Not sure I will be able to recover from errors above and make sure the file is restored...
     if [ -e ${TASK_HOME}/secret.code.orig ]; then
-        mv ${TASK_HOME}/secret.code.orig ${TASK_HOME}/secret.code
+        ( >&2 mv -v ${TASK_HOME}/secret.code.orig ${TASK_HOME}/secret.code )
     fi
     
     # Move in test folder


### PR DESCRIPTION
- the renaming from secret.code to secret.code.orig didn't work, because you were only printing that command; because of that, my already present file was overwritten :(
- removed comment, since this is necessary; the secret.code file is probably present for most people, since it is required to run the program
- both move commands should be consistent in terms of the -v flag; I chose to add it for both, but maybe that is not necessary